### PR TITLE
default size 를 0,0 으로 변경

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -176,8 +176,8 @@ Toast.defaultProps = {
     y: DIVIDER_LINE / 2,
   },
   size: {
-    width: 100,
-    height: 30,
+    width: 0,
+    height: 0,
   },
   containerStyle: {
     justifyContent:  'center',


### PR DESCRIPTION
### 변경내용

토스트팝업 컴포넌트가 기본사이즈를 갖지 않도록 `{ width: 0, height:0 }` 으로 변경하였습니다 